### PR TITLE
Fix spelling erros in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         <!--<h3 class ="mainhead" id="welcome">Welcome to Project GITenberg</h3>-->
         <h3 class="mainhead" id="welcome">$ git commit Alice-in-Wonderland.txt -m "Down the Rabbit Hole..."</h3>
 
-         <p><b>Project GITenberg</b> is a <b>Free and Open</b>, <b>Collaborative</b>, <b>Trackable</b> and <b>Scriptable</b> digital library. It leverages the power of the <b>Git</b> version control system and the collaborative potential of <b><a href="http://www.github.com">Github</a></b> to make books more open.</p> 
+         <p><b>Project GITenberg</b> is a <b>Free and Open</b>, <b>Collaborative</b>, <b>Trackable</b> and <b>Scriptable</b> digital library. It leverages the power of the <b>Git</b> version control system and the collaborative potential of <b><a href="http://www.github.com">GitHub</a></b> to make books more open.</p> 
          <p>Currently there are <a href="http://github.com/GITenberg/">over 43,000 books</a> in GITenberg.</p>
 
 
@@ -38,11 +38,11 @@
         <p class ="subhead">-Free and Open</p>
         <p> Our mission is to curate a <b>free and open</b> library of books. All books are in the public domain and can be corrected, pulled, and forked for any purpose.</p>
         <p class ="subhead">-Collaborative</p>
-        <p>Programmers already have a tried-and-true way to collaborate on projects, <b>Git.</b> <a href="http://Github.com">Github</a> allows this collaboration to be <b>open</b> and <b>social</b>, allowing anyone with a username to maintain our large collection of ebooks. </p>
+        <p>Programmers already have a tried-and-true way to collaborate on projects, <b>Git.</b> <a href="http://github.com">GitHub</a> allows this collaboration to be <b>open</b> and <b>social</b>, allowing anyone with a username to maintain our large collection of ebooks. </p>
         <p class ="subhead">-Trackable</p>
         <p>Leveraging the Git version control system, we can keep track of changes, track open issues with any book, and track contributions.</p>
         <p class ="subhead">-Scriptable</p>
-        <p>Serving books the way we serve code has its benefits. We can use <b>Git</b> and the <b><a href="http://developer.github.com/v3/">Github Api</a></b>, to do things like automatically generate epub and pdf files whenever there is a change stored in Git.</p>
+        <p>Serving books the way we serve code has its benefits. We can use <b>Git</b> and the <b><a href="http://developer.github.com/v3/">GitHub API</a></b>, to do things like automatically generate epub and pdf files whenever there is a change stored in Git.</p>
 
         <!-- Begin MailChimp Signup Form -->
         <link href="//cdn-images.mailchimp.com/embedcode/classic-081711.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
The name of this website is GitHub, not Github.

Furthermore, the official website URL is `https://github.com` and not `https://Github.com`.